### PR TITLE
fix(ci): move pre_release_hook to package config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Install cargo-semver-checks
+        run: cargo install cargo-semver-checks --locked
+
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@v2

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,18 +6,24 @@ git_release_enable = true
 git_release_draft = false
 publish_timeout = "30m"
 
-# Version from conventional commits
-semver_check = false  # no cargo-semver-checks dependency needed
+# Semver
+semver_check = true
+features_always_increment_minor = true
 
+# Keep deps fresh in release PRs
+dependencies_update = true
+
+# Release PR settings
+pr_labels = ["release"]
+
+[[package]]
+name = "ascom-alpaca-core"
 # Bump version in README.md before release commit
 pre_release_hook = { command = "sed", args = [
     "-i",
     "s/ascom-alpaca-core = \"[0-9][^\"]*\"/ascom-alpaca-core = \"{{ version }}\"/g",
     "README.md"
 ] }
-
-[[package]]
-name = "ascom-alpaca-core"
 
 [changelog]
 # Conventional commits → changelog sections


### PR DESCRIPTION
Move pre_release_hook from [workspace] to [[package]] — it's a per-package config option.
