### PR TITLE
docs: DeviceStateBuilder, macros, contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,11 +82,11 @@ src/
 1. Create `src/{device_type}/mod.rs` with the trait (extending `Device`)
 2. Add domain types in `src/{device_type}/types.rs` if needed
 3. Add a feature flag in `Cargo.toml` and wire it into `all-devices`
-4. Add the variant to `RegisteredDevice` in `src/device/mod.rs`
-5. Add typed lookup to `DeviceRegistry` in `src/registry/mod.rs`
+4. Add the variant to `RegisteredDevice` in `src/device/mod.rs` (+ `From` impl)
+5. Add a `typed_getter!` invocation in `src/registry/mod.rs`
 6. Re-export in `src/prelude` (feature-gated)
 7. Add dispatch in `src/conformu/dispatch.rs` (feature-gated)
-8. Add a mock in `src/conformu/mocks/` with ConformU-passing implementation
+8. Add a mock in `src/conformu/mocks/` using `impl_mock_device!` macro + `DeviceStateBuilder`
 9. Register the mock in `examples/conformu_harness.rs`
 
 ## Adding Methods to an Existing Device
@@ -117,6 +117,8 @@ Scopes: `camera`, `telescope`, `dome`, `switch`, `focuser`, `rotator`, `conformu
 - Trait methods return `AlpacaResult<T>` (never panic)
 - Use `AlpacaError` variants, not custom error types
 - Mocks use `Mutex` for interior mutability (single-threaded harness, but trait requires `&self`)
+- Mocks use `impl_mock_device!` macro for `Device` trait boilerplate (see `conformu/mocks/mod.rs`)
+- Use `DeviceStateBuilder` for `device_state()` implementations (both in mocks and consumer code)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,25 @@ let description = ServerDescription {
 };
 ```
 
+### Device State
+
+The `DeviceStateBuilder` provides an ergonomic way to construct the `device_state()` response (Platform 7+):
+
+```rust
+use ascom_alpaca_core::prelude::*;
+
+fn device_state(&self) -> AlpacaResult<Vec<DeviceStateItem>> {
+    Ok(DeviceStateBuilder::new()
+        .add("IsSafe", self.is_safe)
+        .add("TimeSinceLastHeartbeat", self.last_heartbeat.elapsed().as_secs())
+        .add("AlarmActive", self.alarm_active)
+        .add("Armed", self.armed)
+        .build())
+}
+```
+
+The `.add()` method accepts any type that implements `Serialize` — no manual `DeviceStateItem` construction or `serde_json::json!()` needed.
+
 ### Transaction Tracking
 
 ```rust

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,6 +154,29 @@ conformu_harness.rs (tiny_http server)
 - Response envelope construction with transaction IDs
 - Error mapping (trait errors → JSON error responses)
 
+### Internal macros
+
+The ConformU module uses two internal macros to reduce boilerplate:
+
+- **`impl_mock_device!`** (in `mocks/mod.rs`) — generates the `impl Device for MockX` block with standard connected/disconnect/driver_info plumbing. Accepts string literals for most devices or `name_field:`/`unique_id_field:` for devices with dynamic identity (Camera). The `device_state` parameter takes a closure.
+- **`typed_getter!`** (in `registry/mod.rs`) — generates feature-gated `get_<device>(&self, num) -> Result<&dyn Trait, RegistryError>` methods on `DeviceRegistry`. Each invocation maps a method name, feature flag, DeviceType variant, RegisteredDevice variant, and trait path.
+
+These are private — crate users don't interact with them.
+
+### DeviceStateBuilder
+
+`DeviceStateBuilder` (in `device/common.rs`, exported in prelude) is a public API for constructing `Vec<DeviceStateItem>` without manual struct construction:
+
+```rust
+DeviceStateBuilder::new()
+    .add("CameraState", state as i32)
+    .add("Temperature", -10.0)
+    .add("ImageReady", true)
+    .build()
+```
+
+Used internally by all 10 mock `device_state()` implementations and available to crate consumers for their own device implementations.
+
 ### Mock devices
 
 Each mock implements the full device trait with configurable capabilities:


### PR DESCRIPTION
## Summary

- **README**: Add DeviceStateBuilder usage example in Core Concepts section
- **architecture.md**: Document internal macros (impl_mock_device!, typed_getter!) and DeviceStateBuilder
- **CONTRIBUTING.md**: Update "Adding a New Device Type" checklist to reference macros, add DeviceStateBuilder to code style section

Follow-up to #87 (refactor: macros, DeviceStateBuilder, clippy cleanup).
