### PR TITLE
feat(ci): add id-token permission for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   release:
     uses: nightwatch-astro/.github/.github/workflows/rust-release.yml@main


### PR DESCRIPTION
Adds `id-token: write` permission to the release workflow caller so the shared reusable workflow can exchange OIDC tokens with crates.io.