### PR TITLE
ci: bump shared release workflow to App-token version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,1 +1,1 @@
-name: Release  on:   push:     branches: [main]  permissions:   contents: write   pull-requests: write   id-token: write  jobs:   release:     uses: nightwatch-astro/.github/.github/workflows/rust-release.yml@278fc3e6e2ab154e146c07107c95d192919bf84b # main     secrets: inherit
+name: Release  on:   push:     branches: [main]  permissions:   contents: write   pull-requests: write   id-token: write  jobs:   release:     uses: nightwatch-astro/.github/.github/workflows/rust-release.yml@8bc43e99bec3baeafa6a40d458d0cb0931039a1f # main     secrets: inherit


### PR DESCRIPTION
## Summary

- Bumps the pinned SHA of the reusable `rust-release.yml` workflow called by `.github/workflows/release.yml`.
- Old SHA: `278fc3e6e2ab154e146c07107c95d192919bf84b`
- New SHA: `8bc43e99bec3baeafa6a40d458d0cb0931039a1f`

The new version of the shared workflow authenticates via the shared release App instead of the retired `NIGHTWATCH_APP_*` App credentials. This change is required for releases to continue working.

## Change

Only the 40-character SHA on the `uses:` line was changed; everything else (workflow name, `# main` comment, `secrets: inherit`) is byte-for-byte identical.