### PR TITLE
ci: restore newlines in release workflow so it parses again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,1 +1,15 @@
-name: Release  on:   push:     branches: [main]  permissions:   contents: write   pull-requests: write   id-token: write  jobs:   release:     uses: nightwatch-astro/.github/.github/workflows/rust-release.yml@8bc43e99bec3baeafa6a40d458d0cb0931039a1f # main     secrets: inherit
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    uses: nightwatch-astro/.github/.github/workflows/rust-release.yml@8bc43e99bec3baeafa6a40d458d0cb0931039a1f # main
+    secrets: inherit


### PR DESCRIPTION
release.yml was flattened to a single line (newlines replaced by spaces) in the July 10 app-token bump, making the YAML unparseable — every release run since has been a 0-job startup failure. This restores the standard 15-line shared-workflow caller, identical to esp-idf-improv-wifi's working copy (same pinned SHA).